### PR TITLE
Fix fonts not loading on mobile

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,4 +1,4 @@
-html {
+body {
   font-size: 16px;
   font-family: "Martel Sans", serif;
   background-color: #ffffff;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Martel+Sans:wght@400;600;800&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Martel+Sans:wght@200;300;400;600;700;800;900&display=swap"
     rel="stylesheet"
   />
 </head>


### PR DESCRIPTION
Google font is not loading on mobile on Safari and Firefox Focus.

* Set font-family rule in body instead of HTML.

Needs further testing to confirm if this works...